### PR TITLE
Use ON CONFLICT DO NOTHING

### DIFF
--- a/webhook/src/repository.js
+++ b/webhook/src/repository.js
@@ -21,7 +21,7 @@ var insertReading = async function (reading) {
         reading
     ) values (
         $1, $2, $3, $4, $5, $6
-    )`;
+    ) ON CONFLICT DO NOTHING`;
     const values = [macAddress, timestamp, serialNumber, schema, schemaVersion, JSON.stringify(reading)]
     await pool.query(query, values);
 }


### PR DESCRIPTION
It's expected that there might be duplicate attempts to resend messages. There is no reason to bubble up an error. You should use the ON CONFLICT clause. https://www.postgresql.org/docs/current/sql-insert.html#:~:text=ON%20CONFLICT%20DO%20NOTHING%20simply,can%20perform%20unique%20index%20inference.